### PR TITLE
Fix Video Orientation deprecation

### DIFF
--- a/FERN/Views/CameraView.swift
+++ b/FERN/Views/CameraView.swift
@@ -57,7 +57,7 @@ struct CameraPreview: UIViewRepresentable {
         view.backgroundColor = .black
         view.videoPreviewLayer.cornerRadius = 0
         view.videoPreviewLayer.session = session
-        view.videoPreviewLayer.connection?.videoOrientation = .portrait
+        view.videoPreviewLayer.connection?.videoRotationAngle = 90
 
         return view
     }


### PR DESCRIPTION
changed to videoRotationAngle = 90 per swift docs.